### PR TITLE
Java 8 source target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -16,6 +16,8 @@
     <property name="inifile" value="euca-admin.ini"/>
     <property name="tests" value="DefaultSuite.xml"/>
     <property name="ivy.cache.ttl.default" value="1d"/>
+    <property name="javac.source" value="1.8"/>
+    <property name="javac.target" value="${javac.source}"/>
 
     <!-- bootstrap-ivy -->
     <target name="bootstrap-ivy" description="Install ivy">
@@ -40,24 +42,24 @@
     </path>
 
     <!-- delete build and results directories -->
-    <target name="clean">
+    <target name="clean" description="Clean build work, and artifacts">
         <delete dir="${build.dir}"/>
         <delete dir="${deps.dir}"/>
     </target>
 
     <!-- delete build, results and dependencies directories -->
-    <target name="clean-all" depends="clean">
+    <target name="clean-all" depends="clean" description="Clean build work, artifacts and test results">
         <delete dir="${testng.output.dir}"/>
     </target>
 
     <!-- compile all classes of src.dir -->
-    <target name="compile" depends="download-deps">
+    <target name="compile" depends="download-deps" description="Compile tests">
         <mkdir dir="${classes.dir}"/>
         <taskdef name="groovyc"
                  classname="org.codehaus.groovy.ant.Groovyc"
                  classpathref="classpath"/>
         <groovyc srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" includeAntRuntime="no" fork="yes">
-            <javac/>
+            <javac source="${javac.source}" target="${javac.target}" />
         </groovyc>
         <copy file="log4j.properties" todir="${classes.dir}"/>
         <gunzip src="zerofile.gz" dest="${classes.dir}" />
@@ -68,7 +70,7 @@
     <!-- TODO: Have the other tasks check to see if they need to run, or what (if anything) -->
     <!-- needs to be recompiled, to speed up the process. Then we could do away with this target -->
     <!-- and roll it back into runTestNG. -->
-    <target name="test-only">
+    <target name="test-only" description="Run tests without building">
         <taskdef name="testng" classname="org.testng.TestNGAntTask">
             <classpath>
                 <fileset dir="${deps.dir}">
@@ -88,11 +90,11 @@
     </target>
 
     <!-- compile all and run the tests defined by ${tests} -->
-    <target name="runTestNG" depends="compile, test-only"/>
+    <target name="runTestNG" depends="compile, test-only"  description="Build and run tests"/>
 
     <!-- clean, build and run tests -->
-    <target name="clean-build" depends="clean, runTestNG"/>
+    <target name="clean-build" depends="clean, runTestNG" description="Clean, build and run tests"/>
 
     <!-- clean all, build and run tests -->
-    <target name="clean-all-build" depends="clean-all, runTestNG"/>
+    <target name="clean-all-build" depends="clean-all, runTestNG" description="Clean all, build and run tests"/>
 </project>

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingEC2VPC.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingEC2VPC.groovy
@@ -40,17 +40,17 @@ import static N4j.minimalInit
  *
  *   https://eucalyptus.atlassian.net/browse/EUCA-9828
  */
-class TestAutoscalingEC2VPC {
+class TestAutoScalingEC2VPC {
 
   private final String host;
   private final AWSCredentialsProvider credentials
 
   public static void main( String[] args ) throws Exception {
-    final TestAutoscalingEC2VPC test =  new TestAutoscalingEC2VPC();
+    final TestAutoScalingEC2VPC test =  new TestAutoScalingEC2VPC();
     test.test();
   }
 
-  public TestAutoscalingEC2VPC() {
+  public TestAutoScalingEC2VPC() {
     minimalInit()
     this.host = CLC_IP;
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )


### PR DESCRIPTION
This pull request updates the build to specify Java 8 (1.8) for the javac source and target. Descriptions are added for build targets which are displayed when you run "ant -p":

```
$ ant -p
Buildfile: /home/steve/Work/n4j/build.xml

Main targets:

 bootstrap-ivy    Install ivy
 clean            Clean build work, and artifacts
 clean-all        Clean build work, artifacts and test results
 clean-all-build  Clean all, build and run tests
 clean-build      Clean, build and run tests
 compile          Compile tests
 runTestNG        Build and run tests
 test-only        Run tests without building
Default target: clean-build
```

The classname for TestAutoscalingEC2VPC is updated to match the case of the containing file, preventing this test being recompiled on each build.
