### PR TITLE
S3 acl tests updated for aws/s3 compatibility

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/S3MultiPartUploadTests.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/S3MultiPartUploadTests.java
@@ -826,6 +826,7 @@ public class S3MultiPartUploadTests {
       Grant ownerGrant = new Grant(new CanonicalGrantee(ownerId), Permission.FullControl);
       AccessControlList acl = new AccessControlList();
       acl.getGrants().add(new Grant(GroupGrantee.LogDelivery, Permission.WriteAcp));
+      acl.getGrants().add(ownerGrant);
 
       // Inititate mpu with canned ACL
       print(account + ": Initiating multipart upload for object " + key + " in bucket " + bucketName);
@@ -852,7 +853,6 @@ public class S3MultiPartUploadTests {
         }
       });
 
-      acl.getGrants().add(ownerGrant);
       S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);
     } catch (AmazonServiceException ase) {
       printException(ase);

--- a/src/main/java/com/eucalyptus/tests/awssdk/S3ObjectACLTests.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/S3ObjectACLTests.java
@@ -612,25 +612,25 @@ public class S3ObjectACLTests {
       AccessControlList acl = new AccessControlList();
       acl.setOwner(owner);
       acl.getGrants().add(new Grant(GroupGrantee.AuthenticatedUsers, Permission.FullControl));
+      acl.getGrants().add(ownerGrant);
       print(account + ": Setting ACL for " + key + " to " + acl);
       s3.setObjectAcl(bucketName, key, acl);
-      acl.getGrants().add(ownerGrant);
       S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);
 
       acl = new AccessControlList();
       acl.setOwner(owner);
       acl.getGrants().add(new Grant(GroupGrantee.AllUsers, Permission.WriteAcp));
+      acl.getGrants().add(ownerGrant);
       print(account + ": Setting ACL for " + key + " to " + acl);
       s3.setObjectAcl(bucketName, key, acl);
-      acl.getGrants().add(ownerGrant);
       S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);
 
       acl = new AccessControlList();
       acl.setOwner(owner);
       acl.getGrants().add(new Grant(GroupGrantee.LogDelivery, Permission.ReadAcp));
+      acl.getGrants().add(ownerGrant);
       print(account + ": Setting ACL for " + key + " to " + acl);
       s3.setObjectAcl(bucketName, key, acl);
-      acl.getGrants().add(ownerGrant);
       S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);
     } catch (AmazonServiceException ase) {
       printException(ase);


### PR DESCRIPTION
This pull request updates s3 acl related tests so that they pass with current eucalyptus behaviour and also when run against aws/s3.

Without this pull request being merged some of the S3MultiPartUploadTests and S3ObjectACLTests will fail once the following issue is fixed:

* https://eucalyptus.atlassian.net/browse/EUCA-12628
