### PR TITLE
S3 acl default permission verification EUCA-12628

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/S3BucketACLTests.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/S3BucketACLTests.java
@@ -572,6 +572,23 @@ public class S3BucketACLTests {
   }
 
   @Test
+  public void createBucket_ACL_Headers_No_Default() throws Exception {
+    testInfo(this.getClass().getSimpleName() + " - createBucket_ACL_Headers");
+    try {
+      AccessControlList acl = new AccessControlList();
+      acl.getGrants().add(new Grant(GroupGrantee.AuthenticatedUsers, Permission.ReadAcp));
+      acl.getGrants().add(new Grant(GroupGrantee.AuthenticatedUsers, Permission.Write));
+      acl.getGrants().add(new Grant(GroupGrantee.LogDelivery, Permission.Write));
+      acl.getGrants().add(new Grant(GroupGrantee.AllUsers, Permission.FullControl));
+      createBucketWithACL(bucketName, acl);
+      S3Utils.verifyBucketACL(s3, ownerName, bucketName, acl, ownerId);
+    } catch (AmazonServiceException ase) {
+      printException(ase);
+      assertThat(false, "Failed to run createBucket_ACL_Headers");
+    }
+  }
+
+  @Test
   public void setBucket_ACL_XMLBody() throws Exception {
     testInfo(this.getClass().getSimpleName() + " - setBucket_ACL_XMLBody");
     try {
@@ -582,6 +599,25 @@ public class S3BucketACLTests {
       acl.getGrants().add(new Grant(GroupGrantee.LogDelivery, Permission.FullControl));
       acl.getGrants().add(new Grant(GroupGrantee.AllUsers, Permission.WriteAcp));
       acl.getGrants().add(new Grant(new CanonicalGrantee(ownerId), Permission.FullControl));
+      print(account + ": Setting ACL " + acl + " for bucket " + bucketName);
+      s3.setBucketAcl(bucketName, acl);
+      S3Utils.verifyBucketACL(s3, ownerName, bucketName, acl, ownerId);
+    } catch (AmazonServiceException ase) {
+      printException(ase);
+      assertThat(false, "Failed to run setBucket_ACL_XMLBody");
+    }
+  }
+
+  @Test
+  public void setBucket_ACL_XMLBody_No_Default() throws Exception {
+    testInfo(this.getClass().getSimpleName() + " - setBucket_ACL_XMLBody");
+    try {
+      createBucket(bucketName);
+
+      AccessControlList acl = new AccessControlList();
+      acl.setOwner(owner);
+      acl.getGrants().add(new Grant(GroupGrantee.LogDelivery, Permission.FullControl));
+      acl.getGrants().add(new Grant(GroupGrantee.AllUsers, Permission.WriteAcp));
       print(account + ": Setting ACL " + acl + " for bucket " + bucketName);
       s3.setBucketAcl(bucketName, acl);
       S3Utils.verifyBucketACL(s3, ownerName, bucketName, acl, ownerId);

--- a/src/main/java/com/eucalyptus/tests/awssdk/S3ObjectACLTests.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/S3ObjectACLTests.java
@@ -590,6 +590,11 @@ public class S3ObjectACLTests {
       S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);
 
       acl = new AccessControlList();
+      acl.getGrants().add(new Grant(GroupGrantee.AuthenticatedUsers, Permission.Write));
+      putObjectWithACL(bucketName, key, acl);
+      S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);
+
+      acl = new AccessControlList();
       acl.getGrants().add(new Grant(GroupGrantee.LogDelivery, Permission.FullControl));
       acl.getGrants().add(new Grant(GroupGrantee.AllUsers, Permission.ReadAcp));
       acl.getGrants().add(ownerGrant);
@@ -613,6 +618,13 @@ public class S3ObjectACLTests {
       acl.setOwner(owner);
       acl.getGrants().add(new Grant(GroupGrantee.AuthenticatedUsers, Permission.FullControl));
       acl.getGrants().add(ownerGrant);
+      print(account + ": Setting ACL for " + key + " to " + acl);
+      s3.setObjectAcl(bucketName, key, acl);
+      S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);
+
+      acl = new AccessControlList();
+      acl.setOwner(owner);
+      acl.getGrants().add(new Grant(GroupGrantee.AuthenticatedUsers, Permission.FullControl));
       print(account + ": Setting ACL for " + key + " to " + acl);
       s3.setObjectAcl(bucketName, key, acl);
       S3Utils.verifyObjectACL(s3, ownerName, bucketName, key, acl, ownerId);


### PR DESCRIPTION
This pull request adds coverage for the issue:

* https://eucalyptus.atlassian.net/browse/EUCA-12628

by verifying that default owner full control permissions are not added.

This pull request includes the changes in https://github.com/eucalyptus/n4j/pull/46