### PR TITLE
EC2 IAM resource tag condition key test EUCA-8962

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2IAMConditionKeys.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2IAMConditionKeys.groovy
@@ -1,0 +1,1499 @@
+package com.eucalyptus.tests.awssdk
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.model.AttachInternetGatewayRequest
+import com.amazonaws.services.ec2.model.AttachVolumeRequest
+import com.amazonaws.services.ec2.model.AuthorizeSecurityGroupEgressRequest
+import com.amazonaws.services.ec2.model.AuthorizeSecurityGroupIngressRequest
+import com.amazonaws.services.ec2.model.CreateDhcpOptionsRequest
+import com.amazonaws.services.ec2.model.CreateNetworkAclEntryRequest
+import com.amazonaws.services.ec2.model.CreateNetworkAclRequest
+import com.amazonaws.services.ec2.model.CreateRouteRequest
+import com.amazonaws.services.ec2.model.CreateRouteTableRequest
+import com.amazonaws.services.ec2.model.CreateSecurityGroupRequest
+import com.amazonaws.services.ec2.model.CreateTagsRequest
+import com.amazonaws.services.ec2.model.CreateVolumeRequest
+import com.amazonaws.services.ec2.model.CreateVpcRequest
+import com.amazonaws.services.ec2.model.DeleteDhcpOptionsRequest
+import com.amazonaws.services.ec2.model.DeleteInternetGatewayRequest
+import com.amazonaws.services.ec2.model.DeleteNetworkAclEntryRequest
+import com.amazonaws.services.ec2.model.DeleteNetworkAclRequest
+import com.amazonaws.services.ec2.model.DeleteRouteRequest
+import com.amazonaws.services.ec2.model.DeleteRouteTableRequest
+import com.amazonaws.services.ec2.model.DeleteSecurityGroupRequest
+import com.amazonaws.services.ec2.model.DeleteVolumeRequest
+import com.amazonaws.services.ec2.model.DeleteVpcRequest
+import com.amazonaws.services.ec2.model.DescribeImagesRequest
+import com.amazonaws.services.ec2.model.DetachInternetGatewayRequest
+import com.amazonaws.services.ec2.model.DetachVolumeRequest
+import com.amazonaws.services.ec2.model.Filter
+import com.amazonaws.services.ec2.model.IpPermission
+import com.amazonaws.services.ec2.model.RebootInstancesRequest
+import com.amazonaws.services.ec2.model.RevokeSecurityGroupEgressRequest
+import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest
+import com.amazonaws.services.ec2.model.RunInstancesRequest
+import com.amazonaws.services.ec2.model.StartInstancesRequest
+import com.amazonaws.services.ec2.model.StopInstancesRequest
+import com.amazonaws.services.ec2.model.Tag
+import com.amazonaws.services.ec2.model.TerminateInstancesRequest
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient
+import com.amazonaws.services.identitymanagement.model.PutUserPolicyRequest
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
+import org.testng.Assert
+import org.testng.annotations.AfterClass
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import java.util.concurrent.TimeUnit
+
+import static com.eucalyptus.tests.awssdk.N4j.EC2_ENDPOINT
+import static com.eucalyptus.tests.awssdk.N4j.IAM_ENDPOINT
+import static com.eucalyptus.tests.awssdk.N4j.TOKENS_ENDPOINT
+import static com.eucalyptus.tests.awssdk.N4j.assumeThat
+import static com.eucalyptus.tests.awssdk.N4j.createAccount
+import static com.eucalyptus.tests.awssdk.N4j.createUser
+import static com.eucalyptus.tests.awssdk.N4j.deleteAccount
+import static com.eucalyptus.tests.awssdk.N4j.eucaUUID
+import static com.eucalyptus.tests.awssdk.N4j.getCloudInfo
+import static com.eucalyptus.tests.awssdk.N4j.getUserKeys
+import static com.eucalyptus.tests.awssdk.N4j.print
+import static com.eucalyptus.tests.awssdk.N4j.waitForInstances
+import static com.eucalyptus.tests.awssdk.N4j.waitForVolumeAttachments
+
+/**
+ * Test for IAM policy condition keys used with EC2
+ *
+ * This provides coverage for:
+ *   https://eucalyptus.atlassian.net/browse/EUCA-8962
+ */
+class TestEC2IAMConditionKeys {
+
+  // for all tests
+  private String account
+  private String accountNumber
+  private AWSCredentialsProvider accountCredentials
+  private AmazonEC2 accountEc2
+  private AmazonIdentityManagement accountIam
+  private int tagWaitSeconds = 10
+
+  // for each test
+  private List<Runnable> cleanupTasks
+  private String user
+  private AWSCredentialsProvider userCredentials
+
+  @BeforeClass
+  void init( ) {
+    print("### SETUP - ${getClass().simpleName}")
+    getCloudInfo( )
+    account = "${getClass().simpleName.toLowerCase( )}-${eucaUUID()}"
+    createAccount( account )
+    accountCredentials = new AWSStaticCredentialsProvider(
+        getUserKeys( account, 'admin' ).with{ it -> new BasicAWSCredentials( it['ak'], it['sk'] ) } )
+    accountEc2 = AmazonEC2Client.builder( )
+        .withCredentials( accountCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    accountIam = AmazonIdentityManagementClient.builder( )
+        .withCredentials( accountCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( IAM_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    accountNumber = AWSSecurityTokenServiceClient.builder( )
+        .withCredentials( accountCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( TOKENS_ENDPOINT, "eucalyptus" ) )
+        .build( ).getCallerIdentity( new GetCallerIdentityRequest( ) ).account
+  }
+
+  @AfterClass
+  void teardown( ) {
+    print("### CLEANUP - ${getClass().simpleName}")
+    if ( account ) {
+      deleteAccount( account )
+    }
+  }
+
+  @BeforeMethod
+  void initTest(  ) {
+    print( "Initializing user and clean up tasks" )
+    cleanupTasks = [ ]
+    user = "${getClass().simpleName.toLowerCase( )}-user-${eucaUUID()}"
+    createUser( account, user ) // deleted with account
+    userCredentials = new AWSStaticCredentialsProvider(
+        getUserKeys( account, user ).with{ it -> new BasicAWSCredentials( it['ak'], it['sk'] ) } )
+  }
+
+  @AfterMethod
+  void cleanup( ) {
+    Collections.reverse(cleanupTasks)
+    for (final Runnable cleanupTask : cleanupTasks) {
+      try {
+        cleanupTask.run()
+      } catch (Exception e) {
+        print("Unable to run clean up task: ${e}")
+      }
+    }
+  }
+
+  @Test
+  void testTaggedResourceDeletion( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-delete-if-tagged',
+          policyDocument: '''\
+          {
+              "Version": "2012-10-17",
+              "Statement": [
+                  {
+                      "Effect": "Allow",
+                      "Action": [ "ec2:DeleteSecurityGroup", "ec2:DeleteVolume" ],
+                      "Resource": "*",
+                      "Condition": {
+                          "StringEquals": {
+                              "ec2:ResourceTag/delete": "true"
+                          }
+                      }
+                  }
+              ]
+          }
+        '''.stripIndent( )
+      ) )
+    }
+
+    String securityGroupId = null
+    String volumeId = null
+    accountEc2.with {
+      // Find an AZ to use
+      String availabilityZone = describeAvailabilityZones( ).with{
+        availabilityZones?.getAt( 0 )?.zoneName
+      };
+      print( "Using availability zone: ${availabilityZone}" );
+      Assert.assertNotNull( availabilityZone, "Expected availability zone" )
+
+      print( 'Creating volume for delete test' )
+      volumeId = createVolume( new CreateVolumeRequest(
+          size: 1,
+          availabilityZone: availabilityZone
+      ) ).with {
+        volume?.volumeId
+      }
+      print( "Created volume: ${volumeId}" );
+      Assert.assertNotNull( volumeId, "Expected volumeId" )
+      cleanupTasks.add{
+        print( "Deleting volume ${volumeId}" )
+        deleteVolume( new DeleteVolumeRequest( volumeId: volumeId ) )
+      }
+
+      print( 'Creating security group for delete test' )
+      securityGroupId = createSecurityGroup( new CreateSecurityGroupRequest(
+          groupName: 'tagged-resource-delete-test',
+          description: 'Group for testing delete of tagged resources'
+      ) ).with {
+        groupId
+      }
+      print( "Created security group: ${securityGroupId}" );
+      Assert.assertNotNull( securityGroupId, "Expected securityGroupId" )
+      cleanupTasks.add{
+        print( "Deleting security group ${securityGroupId}" )
+        deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: securityGroupId ) )
+      }
+    }
+
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting delete of untagged security group ${securityGroupId} as user" )
+        deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: securityGroupId ) )
+        Assert.fail( 'Expected security group delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting delete of untagged volume ${volumeId} as user" )
+        deleteVolume( new DeleteVolumeRequest( volumeId: volumeId ) )
+        Assert.fail( 'Expected volume delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging security group ${securityGroupId} and volume ${volumeId} with delete=true" )
+      createTags( new CreateTagsRequest(
+          resources: [ securityGroupId, volumeId ],
+          tags: [
+              new Tag( key: 'delete', value: 'true' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting delete of tagged security group ${securityGroupId} as user" )
+      deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: securityGroupId ) )
+
+      print( "Attempting delete of tagged volume ${volumeId} as user" )
+      deleteVolume( new DeleteVolumeRequest( volumeId: volumeId ) )
+    }
+  }
+
+  @Test
+  void testTaggedVpcResourceDeletion( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-delete-if-tagged',
+          policyDocument: '''\
+          {
+              "Version": "2012-10-17",
+              "Statement": [
+                  {
+                      "Effect": "Allow",
+                      "Action": [
+                          "ec2:DeleteDhcpOptions",
+                          "ec2:DeleteInternetGateway",
+                          "ec2:DeleteNetworkAcl",
+                          "ec2:DeleteNetworkAclEntry",
+                          "ec2:DeleteRoute",
+                          "ec2:DeleteRouteTable"
+                      ],
+                      "Resource": "*",
+                      "Condition": {
+                          "StringEquals": {
+                              "ec2:ResourceTag/delete": "true"
+                          }
+                      }
+                  }
+              ]
+          }
+        '''.stripIndent( )
+      ) )
+    }
+
+    String dhcpOptionsId = null
+    String internetGatewayId = null
+    String networkAclId = null
+    String routeTableId = null
+    accountEc2.with {
+      print( 'Creating vpc to contain resources for delete' )
+      String vpcId = createVpc( new CreateVpcRequest(
+          cidrBlock: '10.0.0.0/16'
+      ) ).with {
+        vpc?.vpcId
+      }
+      print( "Created vpc: ${vpcId}" );
+      Assert.assertNotNull( vpcId, "Expected vpcId" )
+      cleanupTasks.add{
+        print( "Deleting vpc ${vpcId}" )
+        deleteVpc( new DeleteVpcRequest( vpcId: vpcId ) )
+      }
+
+      print( 'Creating dhcp options for delete test' )
+      dhcpOptionsId = createDhcpOptions( new CreateDhcpOptionsRequest( ) ).with {
+        dhcpOptions?.dhcpOptionsId
+      }
+      print( "Created dhcp options: ${dhcpOptionsId}" );
+      Assert.assertNotNull( dhcpOptionsId, "Expected dhcpOptionsId" )
+      cleanupTasks.add{
+        print( "Deleting dhcp options ${dhcpOptionsId}" )
+        deleteDhcpOptions( new DeleteDhcpOptionsRequest( dhcpOptionsId: dhcpOptionsId ) )
+      }
+
+      print( 'Creating internet gateway for delete test' )
+      internetGatewayId = createInternetGateway( ).with {
+        internetGateway?.internetGatewayId
+      }
+      print( "Created internet gateway: ${internetGatewayId}" );
+      Assert.assertNotNull( internetGatewayId, "Expected internetGatewayId" )
+      cleanupTasks.add{
+        print( "Deleting internet gateway ${internetGatewayId}" )
+        deleteInternetGateway( new DeleteInternetGatewayRequest( internetGatewayId: internetGatewayId ) )
+      }
+
+      print( 'Creating network acl for delete test' )
+      networkAclId = createNetworkAcl( new CreateNetworkAclRequest( vpcId: vpcId ) ).with {
+        networkAcl?.networkAclId
+      }
+      print( "Created network acl: ${networkAclId}" );
+      Assert.assertNotNull( networkAclId, "Expected networkAclId" )
+      cleanupTasks.add{
+        print( "Deleting network acl ${networkAclId}" )
+        deleteNetworkAcl( new DeleteNetworkAclRequest( networkAclId: networkAclId ) )
+      }
+
+      print( 'Creating network acl entry for delete test' )
+      createNetworkAclEntry( new CreateNetworkAclEntryRequest(
+          networkAclId: networkAclId,
+          ruleNumber: 1000,
+          ruleAction: 'allow',
+          egress: false,
+          cidrBlock: '0.0.0.0/0',
+          protocol: -1
+      ) )
+      print( "Created network acl entry ${networkAclId}/rule#:1000" );
+
+      print( 'Creating route table for delete test' )
+      routeTableId = createRouteTable( new CreateRouteTableRequest( vpcId: vpcId ) ).with {
+        routeTable?.routeTableId
+      }
+      print( "Created route table: ${routeTableId}" );
+      Assert.assertNotNull( routeTableId, "Expected routeTableId" )
+      cleanupTasks.add{
+        print( "Deleting route table ${routeTableId}" )
+        deleteRouteTable( new DeleteRouteTableRequest( routeTableId: routeTableId ) )
+      }
+
+      // attached briefly to allow route creation
+      attachInternetGateway( new AttachInternetGatewayRequest( vpcId: vpcId, internetGatewayId: internetGatewayId ) )
+
+      print( 'Creating route for delete test' )
+      createRoute( new CreateRouteRequest(
+          routeTableId: routeTableId,
+          gatewayId: internetGatewayId,
+          destinationCidrBlock: '1.1.1.1/32'
+      ) )
+      print( "Created route ${routeTableId}/1.1.1.1" );
+
+      detachInternetGateway( new DetachInternetGatewayRequest( vpcId: vpcId, internetGatewayId: internetGatewayId ) )
+
+      void
+    }
+
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting delete of untagged dhcp options ${dhcpOptionsId} as user" )
+        deleteDhcpOptions( new DeleteDhcpOptionsRequest( dhcpOptionsId: dhcpOptionsId ) )
+        Assert.fail( 'Expected dhcp options delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting delete of untagged internet gateway ${internetGatewayId} as user" )
+        deleteInternetGateway( new DeleteInternetGatewayRequest( internetGatewayId: internetGatewayId ) )
+        Assert.fail( 'Expected internet gateway delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting delete of entry from untagged network acl ${networkAclId}/rule#:1000 as user" )
+        deleteNetworkAclEntry( new DeleteNetworkAclEntryRequest(
+            networkAclId: networkAclId,
+            ruleNumber: 1000,
+            egress: false
+        ) )
+        Assert.fail( 'Expected network acl entry delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting delete of untagged network acl ${networkAclId} as user" )
+        deleteNetworkAcl( new DeleteNetworkAclRequest( networkAclId: networkAclId ) )
+        Assert.fail( 'Expected network acl delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting delete of entry from untagged route table ${routeTableId}/1.1.1.1 as user" )
+        deleteRoute( new DeleteRouteRequest(
+            routeTableId: routeTableId,
+            destinationCidrBlock: '1.1.1.1/32'
+        ) )
+        Assert.fail( 'Expected network acl entry delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting delete of untagged route table ${routeTableId} as user" )
+        deleteRouteTable( new DeleteRouteTableRequest( routeTableId: routeTableId ) )
+        Assert.fail( 'Expected route table delete to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging resources ${dhcpOptionsId}, ${internetGatewayId}, ${networkAclId}, ${routeTableId} with delete=true" )
+      createTags( new CreateTagsRequest(
+          resources: [ dhcpOptionsId, internetGatewayId, networkAclId, routeTableId ],
+          tags: [
+              new Tag( key: 'delete', value: 'true' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting delete of tagged dhcp options ${dhcpOptionsId} as user" )
+      deleteDhcpOptions( new DeleteDhcpOptionsRequest( dhcpOptionsId: dhcpOptionsId ) )
+
+      print( "Attempting delete of tagged internet gateway ${internetGatewayId} as user" )
+      deleteInternetGateway( new DeleteInternetGatewayRequest( internetGatewayId: internetGatewayId ) )
+
+      print( "Attempting delete of entry from tagged network acl ${networkAclId}/rule#:1000 as user" )
+      deleteNetworkAclEntry( new DeleteNetworkAclEntryRequest(
+          networkAclId: networkAclId,
+          ruleNumber: 1000,
+          egress: false
+      ) )
+
+      print( "Attempting delete of tagged network acl ${networkAclId} as user" )
+      deleteNetworkAcl( new DeleteNetworkAclRequest( networkAclId: networkAclId ) )
+
+      print( "Attempting delete of entry from tagged route table ${routeTableId}/1.1.1.1 as user" )
+      deleteRoute( new DeleteRouteRequest(
+          routeTableId: routeTableId,
+          destinationCidrBlock: '1.1.1.1/32'
+      ) )
+
+      print( "Attempting delete of tagged route table ${routeTableId} as user" )
+      deleteRouteTable( new DeleteRouteTableRequest( routeTableId: routeTableId ) )
+    }
+  }
+
+  @Test
+  void testTaggedSecurityGroupUpdate( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-update-if-tagged',
+          policyDocument: '''\
+          {
+              "Version": "2012-10-17",
+              "Statement": [
+                  {
+                      "Effect": "Allow",
+                      "Action": [ "ec2:AuthorizesecurityGroupIngress", "ec2:RevokeSecurityGroupIngress" ],
+                      "Resource": "*",
+                      "Condition": {
+                          "StringEquals": {
+                              "ec2:ResourceTag/update": "true"
+                          }
+                      }
+                  }
+              ]
+          }
+        '''.stripIndent( )
+      ) )
+    }
+
+    String securityGroupId = null
+    accountEc2.with {
+      print( 'Creating security group for update test' )
+      securityGroupId = createSecurityGroup( new CreateSecurityGroupRequest(
+          groupName: 'tagged-resource-update-test',
+          description: 'Group for testing update of tagged resources'
+      ) ).with {
+        groupId
+      }
+      print( "Created security group: ${securityGroupId}" );
+      Assert.assertNotNull( securityGroupId, "Expected securityGroupId" )
+      cleanupTasks.add{
+        print( "Deleting security group ${securityGroupId}" )
+        deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: securityGroupId ) )
+      }
+
+      authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 22,
+                  toPort: 22,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+      print( "Authorized tcp:22 ingress for ${securityGroupId}" )
+    }
+
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting authorize of untagged security group ${securityGroupId} tcp:80 as user" )
+        authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
+            groupId: securityGroupId,
+            ipPermissions: [
+                new IpPermission(
+                    ipProtocol: 'tcp',
+                    fromPort: 80,
+                    toPort: 80,
+                    ipRanges: [ '0.0.0.0/0' ]
+                )
+            ]
+        ) )
+        Assert.fail( 'Expected security group authorize to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting revoke of untagged security group ${securityGroupId} tcp:22 as user" )
+        revokeSecurityGroupIngress( new RevokeSecurityGroupIngressRequest(
+            groupId: securityGroupId,
+            ipPermissions: [
+                new IpPermission(
+                    ipProtocol: 'tcp',
+                    fromPort: 22,
+                    toPort: 22,
+                    ipRanges: [ '0.0.0.0/0' ]
+                )
+            ]
+        ) )
+        Assert.fail( 'Expected security group revoke to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging security group ${securityGroupId} with update=true" )
+      createTags( new CreateTagsRequest(
+          resources: [ securityGroupId ],
+          tags: [
+              new Tag( key: 'update', value: 'true' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting authorize of tagged security group ${securityGroupId} tcp:80 as user" )
+      authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 80,
+                  toPort: 80,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+
+      print( "Attempting revoke of tagged security group ${securityGroupId} tcp:22 as user" )
+      revokeSecurityGroupIngress( new RevokeSecurityGroupIngressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 22,
+                  toPort: 22,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+    }
+  }
+
+  @Test
+  void testTaggedVpcSecurityGroupUpdate( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-update-if-tagged',
+          policyDocument: '''\
+          {
+              "Version": "2012-10-17",
+              "Statement": [
+                  {
+                      "Effect": "Allow",
+                      "Action": [
+                          "ec2:AuthorizesecurityGroupEgress",
+                          "ec2:AuthorizesecurityGroupIngress",
+                          "ec2:RevokeSecurityGroupEgress",
+                          "ec2:RevokeSecurityGroupIngress"
+                      ],
+                      "Resource": "*",
+                      "Condition": {
+                          "StringEquals": {
+                              "ec2:ResourceTag/update": "true"
+                          }
+                      }
+                  }
+              ]
+          }
+        '''.stripIndent( )
+      ) )
+    }
+
+    String securityGroupId = null
+    accountEc2.with {
+      print( 'Creating vpc to contain resources for update' )
+      String vpcId = createVpc( new CreateVpcRequest(
+          cidrBlock: '10.0.0.0/16'
+      ) ).with {
+        vpc?.vpcId
+      }
+      print( "Created vpc: ${vpcId}" );
+      Assert.assertNotNull( vpcId, "Expected vpcId" )
+      cleanupTasks.add{
+        print( "Deleting vpc ${vpcId}" )
+        deleteVpc( new DeleteVpcRequest( vpcId: vpcId ) )
+      }
+
+      print( 'Creating security group for update test' )
+      securityGroupId = createSecurityGroup( new CreateSecurityGroupRequest(
+          vpcId: vpcId,
+          groupName: 'tagged-resource-update-test',
+          description: 'Group for testing update of tagged resources'
+      ) ).with {
+        groupId
+      }
+      print( "Created security group: ${securityGroupId}" );
+      Assert.assertNotNull( securityGroupId, "Expected securityGroupId" )
+      cleanupTasks.add{
+        print( "Deleting security group ${securityGroupId}" )
+        deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: securityGroupId ) )
+      }
+
+      authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 22,
+                  toPort: 22,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+      print( "Authorized tcp:22 ingress for ${securityGroupId}" )
+
+      authorizeSecurityGroupEgress( new AuthorizeSecurityGroupEgressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 22,
+                  toPort: 22,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+      print( "Authorized tcp:22 egress for ${securityGroupId}" )
+    }
+
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting authorize egress of untagged security group ${securityGroupId} tcp:80 as user" )
+        authorizeSecurityGroupEgress( new AuthorizeSecurityGroupEgressRequest(
+            groupId: securityGroupId,
+            ipPermissions: [
+                new IpPermission(
+                    ipProtocol: 'tcp',
+                    fromPort: 80,
+                    toPort: 80,
+                    ipRanges: [ '0.0.0.0/0' ]
+                )
+            ]
+        ) )
+        Assert.fail( 'Expected security group authorize egress to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting authorize ingress of untagged security group ${securityGroupId} tcp:80 as user" )
+        authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
+            groupId: securityGroupId,
+            ipPermissions: [
+                new IpPermission(
+                    ipProtocol: 'tcp',
+                    fromPort: 80,
+                    toPort: 80,
+                    ipRanges: [ '0.0.0.0/0' ]
+                )
+            ]
+        ) )
+        Assert.fail( 'Expected security group authorize ingress to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting revoke egress of untagged security group ${securityGroupId} tcp:22 as user" )
+        revokeSecurityGroupEgress( new RevokeSecurityGroupEgressRequest(
+            groupId: securityGroupId,
+            ipPermissions: [
+                new IpPermission(
+                    ipProtocol: 'tcp',
+                    fromPort: 22,
+                    toPort: 22,
+                    ipRanges: [ '0.0.0.0/0' ]
+                )
+            ]
+        ) )
+        Assert.fail( 'Expected security group revoke egress to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting revoke ingress of untagged security group ${securityGroupId} tcp:22 as user" )
+        revokeSecurityGroupIngress( new RevokeSecurityGroupIngressRequest(
+            groupId: securityGroupId,
+            ipPermissions: [
+                new IpPermission(
+                    ipProtocol: 'tcp',
+                    fromPort: 22,
+                    toPort: 22,
+                    ipRanges: [ '0.0.0.0/0' ]
+                )
+            ]
+        ) )
+        Assert.fail( 'Expected security group revoke ingress to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging security group ${securityGroupId} with update=true" )
+      createTags( new CreateTagsRequest(
+          resources: [ securityGroupId ],
+          tags: [
+              new Tag( key: 'update', value: 'true' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting authorize egress of untagged security group ${securityGroupId} tcp:80 as user" )
+      authorizeSecurityGroupEgress( new AuthorizeSecurityGroupEgressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 80,
+                  toPort: 80,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+
+      print( "Attempting authorize ingress of tagged security group ${securityGroupId} tcp:80 as user" )
+      authorizeSecurityGroupIngress( new AuthorizeSecurityGroupIngressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 80,
+                  toPort: 80,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+
+      print( "Attempting revoke egress of untagged security group ${securityGroupId} tcp:22 as user" )
+      revokeSecurityGroupEgress( new RevokeSecurityGroupEgressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 22,
+                  toPort: 22,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+
+      print( "Attempting revoke ingress of tagged security group ${securityGroupId} tcp:22 as user" )
+      revokeSecurityGroupIngress( new RevokeSecurityGroupIngressRequest(
+          groupId: securityGroupId,
+          ipPermissions: [
+              new IpPermission(
+                  ipProtocol: 'tcp',
+                  fromPort: 22,
+                  toPort: 22,
+                  ipRanges: [ '0.0.0.0/0' ]
+              )
+          ]
+      ) )
+    }
+  }
+
+  @Test
+  void testTaggedInstanceRebootAndTerminate( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-terminate-instances-if-tagged',
+          policyDocument: '''\
+          {
+              "Version": "2012-10-17",
+              "Statement": [
+                  {
+                      "Effect": "Allow",
+                      "Action": [
+                          "ec2:RebootInstances",
+                          "ec2:TerminateInstances"
+                      ],
+                      "Resource": "*",
+                      "Condition": {
+                          "StringEquals": {
+                              "ec2:ResourceTag/purpose": "test"
+                          }
+                      }
+                  }
+              ]
+          }
+        '''.stripIndent( )
+      ) )
+    }
+
+    String instanceId = null
+    accountEc2.with {
+      // Find an image to use
+      String imageId = describeImages( new DescribeImagesRequest(
+          filters: [
+              new Filter( name: 'image-type', values: ['machine'] ),
+              new Filter( name: 'is-public', values: ['true'] ),
+              new Filter( name: 'root-device-type', values: ['instance-store'] ),
+          ]
+      ) ).with {
+        images?.getAt( 0 )?.imageId
+      }
+      Assert.assertNotNull( imageId, "Public instance-store image not found" )
+      print( "Using image: ${imageId}" )
+
+      // Run instance without any tags
+      print( 'Launching instance for termination test' )
+      instanceId = runInstances( new RunInstancesRequest(
+          minCount: 1,
+          maxCount: 1,
+          imageId: imageId
+      ) ).with {
+        reservation?.instances?.getAt(0)?.instanceId
+      }
+      print( "Launched instance: ${instanceId}" )
+      Assert.assertNotNull( instanceId, "Expected instance identifier" )
+
+      cleanupTasks.add{
+        print( "Terminating instance ${instanceId}" )
+        terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+      }
+    }
+
+    // Terminate without permission
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting reboot of untagged instance ${instanceId} as user" )
+        rebootInstances( new RebootInstancesRequest( instanceIds: [instanceId ] ) )
+        Assert.fail( 'Expected instance reboot to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting terminate of untagged instance ${instanceId} as user" )
+        terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+        Assert.fail( 'Expected instance termination to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging instance ${instanceId} with purpose=test" )
+      createTags( new CreateTagsRequest(
+          resources: [ instanceId ],
+          tags: [
+            new Tag( key: 'purpose', value: 'test' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting reboot of tagged instance ${instanceId} as user" )
+      rebootInstances( new RebootInstancesRequest( instanceIds: [instanceId ] ) )
+
+      print( "Attempting terminate of tagged instance ${instanceId} as user" )
+      terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+    }
+  }
+
+  @Test
+  void testTaggedInstanceVolumeAttachDetach( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-instance-volume-attachment-if-tagged',
+          policyDocument: """\
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "ec2:AttachVolume",
+                            "ec2:DetachVolume"
+                        ],
+                        "Resource": "arn:aws:ec2::${accountNumber}:instance/*",
+                        "Condition": {
+                            "StringEquals": {
+                                "ec2:ResourceTag/department": "dev"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "ec2:AttachVolume",
+                            "ec2:DetachVolume"
+                        ],
+                        "Resource": "arn:aws:ec2::${accountNumber}:volume/*",
+                        "Condition": {
+                            "StringEquals": {
+                                "ec2:ResourceTag/volume_user": "\${aws:username}"
+                            }
+                        }
+                    }
+                ]
+            }
+          """.stripIndent( )
+      ) )
+    }
+
+    String instanceId = null
+    String volumeId_1 = null
+    String volumeId_2 = null
+    accountEc2.with {
+      // Find an image to use
+      String imageId = describeImages( new DescribeImagesRequest(
+          filters: [
+              new Filter( name: 'image-type', values: ['machine'] ),
+              new Filter( name: 'is-public', values: ['true'] ),
+              new Filter( name: 'root-device-type', values: ['instance-store'] ),
+          ]
+      ) ).with {
+        images?.getAt( 0 )?.imageId
+      }
+      Assert.assertNotNull( imageId, "Public instance-store image not found" )
+      print( "Using image: ${imageId}" )
+
+      // Find an AZ to use
+      String availabilityZone = describeAvailabilityZones( ).with{
+        availabilityZones?.getAt( 0 )?.zoneName
+      };
+      print( "Using availability zone: ${availabilityZone}" );
+      Assert.assertNotNull( availabilityZone, "Expected availability zone" )
+
+      def volumeCreate = { String desc ->
+        print( "Creating volume ${desc} for delete test" )
+        String volumeId = createVolume( new CreateVolumeRequest(
+            size: 1,
+            availabilityZone: availabilityZone
+        ) ).with {
+          volume?.volumeId
+        }
+        print( "Created volume ${desc}: ${volumeId}" );
+        Assert.assertNotNull( volumeId, "Expected volumeId" )
+        cleanupTasks.add{
+          print( "Deleting volume ${desc} ${volumeId}" )
+          deleteVolume( new DeleteVolumeRequest( volumeId: volumeId ) )
+        }
+        volumeId
+      }
+      volumeId_1 = volumeCreate( '1' )
+      volumeId_2 = volumeCreate( '2' )
+
+      // Run instance without any tags
+      print( 'Launching instance for termination test' )
+      instanceId = runInstances( new RunInstancesRequest(
+          minCount: 1,
+          maxCount: 1,
+          imageId: imageId
+      ) ).with {
+        reservation?.instances?.getAt(0)?.instanceId
+      }
+      print( "Launched instance: ${instanceId}" )
+      Assert.assertNotNull( instanceId, "Expected instance identifier" )
+      cleanupTasks.add{
+        print( "Terminating instance ${instanceId}" )
+        terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+      }
+    }
+
+    // Wait until running
+    print( 'Waiting for instances to be running...' )
+    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 2 ) )
+
+    accountEc2.with {
+      print( "Attaching volume ${volumeId_2} to instance ${instanceId} for detach testing" )
+      attachVolume( new AttachVolumeRequest(
+          instanceId: instanceId,
+          volumeId: volumeId_2,
+          device: '/dev/sdg'
+      ) )
+
+      print( 'Waiting for volumes to be attached' )
+      waitForVolumeAttachments( accountEc2, TimeUnit.MINUTES.toMillis( 2 ) )
+    }
+
+    // Attach / detach without permission
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting attach of untagged volume ${volumeId_1} to untagged instance ${instanceId} as user" )
+        attachVolume( new AttachVolumeRequest(
+            instanceId: instanceId,
+            volumeId: volumeId_1,
+            device: '/dev/sdf'
+        ) )
+        Assert.fail( 'Expected instance volume attach to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting detach of untagged volume ${volumeId_2} from untagged instance ${instanceId} as user" )
+        detachVolume( new DetachVolumeRequest(
+            instanceId: instanceId,
+            volumeId: volumeId_2,
+            device: '/dev/sdg'
+        ) )
+        Assert.fail( 'Expected instance volume detach to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging instance ${instanceId} with department=dev" )
+      createTags( new CreateTagsRequest(
+          resources: [ instanceId ],
+          tags: [
+              new Tag( key: 'department', value: 'dev' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      try {
+        print( "Attempting attach of untagged volume ${volumeId_1} to tagged instance ${instanceId} as user" )
+        attachVolume( new AttachVolumeRequest(
+            instanceId: instanceId,
+            volumeId: volumeId_1,
+            device: '/dev/sdf'
+        ) )
+        Assert.fail( 'Expected instance volume attach to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting detach of untagged volume ${volumeId_2} from tagged instance ${instanceId} as user" )
+        detachVolume( new DetachVolumeRequest(
+            instanceId: instanceId,
+            volumeId: volumeId_2,
+            device: '/dev/sdg'
+        ) )
+        Assert.fail( 'Expected instance volume detach to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging volumes ${volumeId_1} ${volumeId_2} with volume_user=${user}" )
+      createTags( new CreateTagsRequest(
+          resources: [ volumeId_1, volumeId_2 ],
+          tags: [
+              new Tag( key: 'volume_user', value: user )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting attach of tagged volume ${volumeId_1} to tagged instance ${instanceId} as user" )
+      attachVolume( new AttachVolumeRequest(
+          instanceId: instanceId,
+          volumeId: volumeId_1,
+          device: '/dev/sdf'
+      ) )
+
+      print( "Attempting detach of tagged volume ${volumeId_2} from tagged instance ${instanceId} as user" )
+      detachVolume( new DetachVolumeRequest(
+          instanceId: instanceId,
+          volumeId: volumeId_2,
+          device: '/dev/sdg'
+      ) )
+    }
+  }
+
+  @Test
+  void testTaggedInstanceStartStop( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-instance-volume-attachment-if-tagged',
+          policyDocument: """\
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "ec2:StartInstances",
+                            "ec2:StopInstances"
+                        ],
+                        "Resource": "arn:aws:ec2::${accountNumber}:instance/*",
+                        "Condition": {
+                            "StringEquals": {
+                                "ec2:ResourceTag/ebs": "1"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "ec2:StartInstances",
+                            "ec2:StopInstances"
+                        ],
+                        "Resource": [
+                            "arn:aws:ec2:::availabilityzone/*",
+                            "arn:aws:ec2:::image/*",
+                            "arn:aws:ec2:::keypair/*",
+                            "arn:aws:ec2:::securitygroup/*",
+                            "arn:aws:ec2:::vmtype/*"
+                        ]
+                    }
+                ]
+            }
+          """.stripIndent( )
+      ) )
+    }
+
+    String instanceId_1 = null
+    String instanceId_2 = null
+    accountEc2.with {
+      // Find an image to use
+      String imageId = describeImages( new DescribeImagesRequest(
+          filters: [
+              new Filter( name: 'image-type', values: ['machine'] ),
+              new Filter( name: 'is-public', values: ['true'] ),
+              new Filter( name: 'root-device-type', values: ['ebs'] ),
+          ]
+      ) ).with {
+        images?.getAt( 0 )?.imageId
+      }
+      assumeThat( imageId != null, "Public ebs image not found" )
+      print( "Using image: ${imageId}" )
+
+      // Find an AZ to use
+      String availabilityZone = describeAvailabilityZones( ).with{
+        availabilityZones?.getAt( 0 )?.zoneName
+      };
+      print( "Using availability zone: ${availabilityZone}" );
+      Assert.assertNotNull( availabilityZone, "Expected availability zone" )
+
+      // Run instance without any tags
+      def launchInstance = { String desc ->
+        print( "Launching instance ${desc} for start/stop test" )
+        String instanceId = runInstances( new RunInstancesRequest(
+            minCount: 1,
+            maxCount: 1,
+            imageId: imageId
+        ) ).with {
+          reservation?.instances?.getAt(0)?.instanceId
+        }
+        print( "Launched instance ${desc}: ${instanceId}" )
+        Assert.assertNotNull( instanceId, "Expected instance identifier" )
+        cleanupTasks.add{
+          print( "Terminating instance ${desc} ${instanceId}" )
+          terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+        }
+        instanceId
+      }
+      instanceId_1 = launchInstance( '1' )
+      instanceId_2 = launchInstance( '2' )
+    }
+
+    // Wait until running
+    print( 'Waiting for instances to be running...' )
+    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 2 ) )
+
+    accountEc2.with {
+      print( "Stopping instance ${instanceId_1} for start testing" )
+      stopInstances( new StopInstancesRequest( instanceIds: [ instanceId_1 ]) )
+    }
+
+    // Wait until stopped
+    print( 'Waiting for instance to be stopped...' )
+    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 2 ) )
+
+    // Start / stop without permission
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting start of untagged instance ${instanceId_1} as user" )
+        startInstances( new StartInstancesRequest( instanceIds: [instanceId_1] ) )
+        Assert.fail( 'Expected instance start to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      try {
+        print( "Attempting stop of untagged instance ${instanceId_2} as user" )
+        stopInstances( new StopInstancesRequest( instanceIds: [ instanceId_2 ] ) ).with {
+          Assert.assertTrue( stoppingInstances.isEmpty( ), 'Expected instance stop to fail'  )
+        }
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging instances ${instanceId_1} ${instanceId_2} with ebs=1" )
+      createTags( new CreateTagsRequest(
+          resources: [ instanceId_1, instanceId_2 ],
+          tags: [
+              new Tag( key: 'ebs', value: '1' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting start of tagged instance ${instanceId_1} as user" )
+      startInstances( new StartInstancesRequest( instanceIds: [instanceId_1] ) )
+
+      print( "Attempting stop of tagged instance ${instanceId_2} as user" )
+      stopInstances( new StopInstancesRequest( instanceIds: [ instanceId_2 ] ) ).with {
+        Assert.assertFalse( stoppingInstances.isEmpty( ), 'Expected stopping instance'  )
+      }
+    }
+  }
+
+  @Test
+  void testTaggedResourcesRunInstance( ) {
+    accountIam.with{
+      putUserPolicy( new PutUserPolicyRequest(
+          userName: this.user,
+          policyName: 'ec2-run-instance-if-resources-tagged',
+          policyDocument: """\
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "ec2:RunInstances",
+                        "Resource": [
+                            "arn:aws:ec2:::availabilityzone/*",
+                            "arn:aws:ec2:::instance/*",
+                            "arn:aws:ec2:::keypair/*",
+                            "arn:aws:ec2:::vmtype/*"
+                        ]
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": "ec2:RunInstances",
+                          "Resource": [
+                            "arn:aws:ec2:::image/*",
+                            "arn:aws:ec2:::securitygroup/*"
+                        ],
+                        "Condition": {
+                            "StringEquals": {
+                                "ec2:ResourceTag/runwithit": "youwill"
+                            }
+                        }
+                    }
+                ]
+            }
+          """.stripIndent( )
+      ) )
+    }
+
+    String imageId = null
+    String securityGroupId = null
+    accountEc2.with {
+      // Find an image to use
+      imageId = describeImages(new DescribeImagesRequest(
+          filters: [
+              new Filter(name: 'image-type', values: ['machine']),
+              new Filter(name: 'is-public', values: ['true']),
+              new Filter(name: 'root-device-type', values: ['instance-store']),
+          ]
+      )).with {
+        images?.getAt(0)?.imageId
+      }
+      Assert.assertNotNull(imageId, "Public instance-store image not found")
+      print("Using image: ${imageId}")
+
+      print( 'Creating security group for run instances test' )
+      securityGroupId = createSecurityGroup( new CreateSecurityGroupRequest(
+          groupName: 'tagged-resource-run-instances-test',
+          description: 'Group for testing instance launch with tagged resources'
+      ) ).with {
+        groupId
+      }
+      print( "Created security group: ${securityGroupId}" );
+      Assert.assertNotNull( securityGroupId, "Expected securityGroupId" )
+      cleanupTasks.add{
+        print( "Deleting security group ${securityGroupId}" )
+        deleteSecurityGroup( new DeleteSecurityGroupRequest( groupId: securityGroupId ) )
+      }
+    }
+
+    // Run using untagged resources
+    AmazonEC2 userEc2 = AmazonEC2Client.builder( )
+        .withCredentials( userCredentials )
+        .withEndpointConfiguration( new EndpointConfiguration( EC2_ENDPOINT, "eucalyptus" ) )
+        .build( )
+    userEc2.with {
+      try {
+        print( "Attempting launch of instance using untagged image ${imageId} and group ${securityGroupId} as user" )
+        String instanceId = runInstances( new RunInstancesRequest(
+            minCount: 1,
+            maxCount: 1,
+            imageId: imageId,
+            securityGroupIds: [ securityGroupId ]
+        ) ).with {
+          reservation?.instances?.getAt(0)?.instanceId
+        }
+        cleanupTasks.add{
+          print( "Terminating instance ${instanceId}" )
+          accountEc2.terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+        }
+        Assert.fail( 'Expected launch instance to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging group ${securityGroupId} with runwithit=youwill" )
+      createTags( new CreateTagsRequest(
+          resources: [ securityGroupId ],
+          tags: [
+              new Tag( key: 'runwithit', value: 'youwill' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      try {
+        print( "Attempting launch of instance using untagged image ${imageId} and tagged group ${securityGroupId} as user" )
+        String instanceId = runInstances( new RunInstancesRequest(
+            minCount: 1,
+            maxCount: 1,
+            imageId: imageId,
+            securityGroupIds: [ securityGroupId ]
+        ) ).with {
+          reservation?.instances?.getAt(0)?.instanceId
+        }
+        cleanupTasks.add{
+          print( "Terminating instance ${instanceId}" )
+          accountEc2.terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+        }
+        Assert.fail( 'Expected launch instance to fail' )
+      } catch ( AmazonServiceException e ) {
+        print( "Got expected exception: ${e}" )
+      }
+
+      void
+    }
+
+    accountEc2.with {
+      print( "Tagging image ${imageId} with runwithit=youwill" )
+      createTags( new CreateTagsRequest(
+          resources: [ imageId ],
+          tags: [
+              new Tag( key: 'runwithit', value: 'youwill' )
+          ]
+      ) )
+    }
+
+    print( "Sleeping to allow tags to apply" )
+    N4j.sleep( tagWaitSeconds )
+
+    userEc2.with {
+      print( "Attempting launch of instance using tagged image ${imageId} and group ${securityGroupId} as user" )
+      String instanceId = runInstances( new RunInstancesRequest(
+          minCount: 1,
+          maxCount: 1,
+          imageId: imageId,
+          securityGroupIds: [ securityGroupId ]
+      ) ).with {
+        reservation?.instances?.getAt(0)?.instanceId
+      }
+      cleanupTasks.add{
+        print( "Terminating instance ${instanceId}" )
+        accountEc2.terminateInstances( new TerminateInstancesRequest( instanceIds: [ instanceId ] ) )
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds TestEC2IAMConditionKeys with coverage for the story:

* https://eucalyptus.atlassian.net/browse/EUCA-8962

The test covers some vpc resources but can be run against an edge cloud. The test will cover instance start/stop if a public ebs image is available, else it will skip that test.

The test runs in a few minutes, so could be added to the regular qa sequence.